### PR TITLE
feat: add liquid glass contrast enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 :root{
   /* Pastels */
   --blush:#FADADD; --peach:#F6D0B1; --ivory:#FFF8F0; --champ:#D9B26D;
-  --rose:#B76E79; --sage:#BFC9B3; --text:#3A2E2E; --muted:#6B5E5E;
+  --rose:#B76E79; --sage:#BFC9B3; --text:#3A2E2E; --muted:#5A4F4F;
   --bg:var(--ivory); --accent:var(--rose);
   --maxw:1200px; --radius:14px; --shadow:0 10px 30px rgba(0,0,0,.06);
 
@@ -119,11 +119,10 @@ nav a:hover{background:#fff;border:1px solid #f0e6da}
 .hero{
   position:relative;isolation:isolate;border-bottom:1px solid #f1e7db;
   background-image:
-    url('IMAGES/IMG_4972.jpg'),
     radial-gradient(1000px 400px at 10% -10%, #ffe9ef 0, rgba(0,0,0,0) 60%),
     radial-gradient(800px 350px at 90% -20%, #ffe0d1 0, rgba(0,0,0,0) 60%),
     linear-gradient(180deg,#fff8f0 0,#fff 50%,#fff8f0 100%);
-  background-size:cover,cover,cover,cover;background-position:center,center,center,center;background-repeat:no-repeat
+  background-size:cover,cover,cover;background-position:center,center,center;background-repeat:no-repeat
 }
 .hero .wrap{display:grid;grid-template-columns:1.2fr .8fr;gap:30px;align-items:center;padding:40px 20px 30px}
 .tag{display:inline-block;background:linear-gradient(90deg,var(--blush),var(--peach));padding:6px 12px;border-radius:999px;font-weight:600;border:1px solid #f3d5c4}
@@ -131,23 +130,42 @@ nav a:hover{background:#fff;border:1px solid #f0e6da}
 .scriptline{font-size:clamp(22px,4.2vw,32px);color:var(--accent);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 @media (max-width:420px){ .scriptline{white-space:normal;overflow:visible;text-overflow:clip;line-height:1.25} }
 .cta{display:flex;gap:12px;flex-wrap:wrap;margin-top:18px}
-.btn{border:1px solid #eadfce;background:#fff;border-radius:999px;padding:12px 18px;box-shadow:var(--shadow)}
+.btn{border:1px solid #eadfce;background:#fff;border-radius:999px;padding:12px 18px;box-shadow:var(--shadow);transition:box-shadow .2s,transform .2s}
 .btn.primary{background:linear-gradient(90deg,var(--blush),var(--peach));border-color:#f0cdb9}
+.btn:hover,.btn:focus-visible{box-shadow:0 12px 32px rgba(0,0,0,.15);transform:translateY(-1px)}
 .note{color:var(--muted);font-size:.9rem}
+
+/* Hero image */
+.hero-img{width:100%;border-radius:16px;box-shadow:var(--shadow)}
 
 /* Frosted glass */
 .glass{
+  position:relative;overflow:hidden;
   background:rgba(255,248,240,.58);
-  -webkit-backdrop-filter: blur(10px) saturate(120%);
-  backdrop-filter: blur(10px) saturate(120%);
-  border:1px solid rgba(233,223,210,.75);border-radius:16px;box-shadow:0 12px 28px rgba(0,0,0,.12);padding:18px
+  -webkit-backdrop-filter: blur(10px) saturate(120%) contrast(1.1) brightness(1.1);
+  backdrop-filter: blur(10px) saturate(120%) contrast(1.1) brightness(1.1);
+  border:1px solid rgba(233,223,210,.85);border-radius:16px;box-shadow:0 12px 28px rgba(0,0,0,.12);padding:18px;
+  --shine-x:.5;--shine-y:.5;
 }
+.glass::before{
+  content:"";position:absolute;inset:0;border-radius:inherit;pointer-events:none;
+  background:radial-gradient(circle at calc(var(--shine-x)*100%) calc(var(--shine-y)*100%),rgba(255,255,255,.6),rgba(255,255,255,0) 60%);
+  mix-blend-mode:overlay;transition:background .2s;
+}
+.glass::after{
+  content:"";position:absolute;inset:-50%;border-radius:inherit;pointer-events:none;
+  background:conic-gradient(from 0deg at 50% 50%,rgba(255,255,255,.25) 0deg,rgba(255,255,255,0) 60deg,rgba(255,255,255,.25) 120deg,rgba(255,255,255,0) 180deg);
+  animation:lens 20s linear infinite;
+  mix-blend-mode:soft-light;
+}
+@keyframes lens{to{transform:rotate(1turn)}}
 
 /* Mobile hero */
 @media (max-width:820px){
   .hero .wrap{grid-template-columns:1fr;padding:20px 0;justify-items:center}
   .glass{margin:0 auto;width:calc(100vw - 40px);max-width:720px}
-  .hero{background-size:160% auto,cover,cover,cover;background-position:center,center,center,center}
+  .hero{background-size:cover,cover,cover;background-position:center,center,center}
+  .hero-img{display:none}
 }
 
 /* Sections */
@@ -187,7 +205,8 @@ select,input[type="number"],input[type="text"],input[type="date"],input[type="fi
 
 /* Contact Buttons */
 .cta-buttons{display:flex;gap:12px;flex-wrap:wrap}
-.iconbtn{display:inline-flex;align-items:center;padding:12px 16px;border:1px solid #eadfce;border-radius:999px;background:#fff;box-shadow:var(--shadow);color:#3A2E2E;font-size:1rem;line-height:1.3;box-sizing:border-box}
+.iconbtn{display:inline-flex;align-items:center;padding:12px 16px;border:1px solid #eadfce;border-radius:999px;background:#fff;box-shadow:var(--shadow);color:#3A2E2E;font-size:1rem;line-height:1.3;box-sizing:border-box;transition:box-shadow .2s,transform .2s}
+.iconbtn:hover,.iconbtn:focus-visible{box-shadow:0 12px 32px rgba(0,0,0,.15);transform:translateY(-1px)}
 .iconbtn svg{width:20px;height:20px;flex:0 0 auto}
 .iconbtn svg + span{margin-left:8px}
 .iconbtn span + svg{margin-left:8px}
@@ -242,9 +261,6 @@ input[type="date"]{-webkit-appearance:none;appearance:none;background-clip:paddi
 </head>
 <body>
 
-<!-- Hidden LCP hint for hero background -->
-<img src="IMAGES/IMG_4972.jpg" alt="" width="1200" height="800" decoding="async" fetchpriority="high" aria-hidden="true" inert style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">
-
 <header>
   <div class="wrap nav">
     <div class="brand">
@@ -282,7 +298,7 @@ input[type="date"]{-webkit-appearance:none;appearance:none;background-clip:paddi
         <a class="btn primary" href="#estimator">Design your cake</a>
       </div>
     </div>
-    <div aria-hidden="true"></div>
+    <div aria-hidden="true"><img src="IMAGES/IMG_4972.jpg" alt="" class="hero-img" width="600" height="400" decoding="async" fetchpriority="high"></div>
   </div>
 </main>
 
@@ -1109,6 +1125,21 @@ calc();
 
     // One robust handler for both
     a.addEventListener('click', openIG, {passive:false});
+  });
+})();
+</script>
+
+<script>
+/* === Dynamic glass highlight (simple liquid glass effect) === */
+(function(){
+  var glass = document.querySelector('.glass');
+  if(!glass) return;
+  glass.addEventListener('pointermove', function(e){
+    var rect = glass.getBoundingClientRect();
+    var x = (e.clientX - rect.left) / rect.width;
+    var y = (e.clientY - rect.top) / rect.height;
+    glass.style.setProperty('--shine-x', x.toFixed(2));
+    glass.style.setProperty('--shine-y', y.toFixed(2));
   });
 })();
 </script>


### PR DESCRIPTION
## Summary
- darken muted text color for better readability
- add liquid glass highlight with dynamic shimmer
- animate buttons and icons for micro-interactions
- restore missing hero banner image

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a775e73c833296d4b75bcc82cddd