### PR TITLE
Add animated status banner that links to contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,8 @@
 
   /* Header sizing (unchanged) */
   --header-h:112px;
-  --anchor-offset:112px;
+  --banner-h:0px;
+  --anchor-offset:calc(var(--header-h) + var(--banner-h));
 
   /* Logo tuning */
   --logo-zoom:1.8;     
@@ -47,7 +48,8 @@
 }
 @media (max-width:820px){
   :root{
-    --header-h:88px; --anchor-offset:92px;
+    --header-h:88px;
+    --anchor-offset:calc(var(--header-h) + var(--banner-h));
     --logo-zoom:1.8;
     --logo-shift-x:50%;
     --logo-shift-y:15%;
@@ -72,7 +74,7 @@ p{margin:.6rem 0}
 
 /* Header */
 header{
-  position:sticky;top:0;z-index:50;
+  position:sticky;top:var(--banner-h);z-index:50;
   background:rgba(255,248,240,.85);
   backdrop-filter:saturate(150%) blur(8px);
   border-bottom:1px solid #f1e7db
@@ -238,12 +240,43 @@ input[type="date"]{-webkit-appearance:none;appearance:none;background-clip:paddi
 @media (max-width:820px){ .tier-ff{grid-template-columns:1fr} }
 .tier-ff h4{margin:.2rem 0 .2rem;font:600 1rem "Playfair Display",serif;color:#2b2222}
 .tier-ff .box{border:1px solid #f0e6da;border-radius:12px;padding:12px;background:#fff}
+
+.temp-banner{
+  position:sticky;top:0;z-index:60;
+  text-align:center;padding:12px 20px;
+  background:rgba(255,248,240,.65);
+  backdrop-filter:blur(8px) saturate(120%);
+  border-bottom:2px solid var(--accent);
+  color:var(--text);font-weight:600;
+  animation:bannerSlide .6s ease-out;
+}
+.temp-banner a{color:var(--accent);text-decoration:underline;}
+@keyframes bannerSlide{
+  from{transform:translateY(-100%);opacity:0;}
+  to{transform:translateY(0);opacity:1;}
+}
 </style>
 </head>
 <body>
 
+<div class="temp-banner">
+  🚧 Our website is still baking!<br>
+  In the meantime, we’d love to hear from you.
+  (<a href="#contact">Contact us for orders or enquiries.</a>)
+</div>
+
 <!-- Hidden LCP hint for hero background -->
 <img src="IMAGES/IMG_4972.jpg" alt="" width="1200" height="800" decoding="async" fetchpriority="high" aria-hidden="true" inert style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">
+
+<script>
+(function(){
+  var b=document.querySelector('.temp-banner');
+  if(b){
+    var h=b.offsetHeight;
+    document.documentElement.style.setProperty('--banner-h', h+'px');
+  }
+})();
+</script>
 
 <header>
   <div class="wrap nav">


### PR DESCRIPTION
## Summary
- add frosted-glass temporary banner announcing site is still baking
- link banner text to contact section and animate slide-in
- adjust header offset via CSS variable and script to accommodate banner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b8c4c0fc83329c6d7d4d9bd85b06