### PR TITLE
Add glass fade animation for sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,12 +70,19 @@ h3{font:600 1.2rem "Playfair Display",serif}
 p{margin:.6rem 0}
 .wrap{max-width:var(--maxw);margin:0 auto;padding:0 20px}
 
+@keyframes glassFade{
+  0%{background:rgba(255,248,240,0);backdrop-filter:saturate(120%) blur(0)}
+  to{background:rgba(255,248,240,.85);backdrop-filter:saturate(150%) blur(8px)}
+}
+
 /* Header */
 header{
   position:sticky;top:0;z-index:50;
   background:rgba(255,248,240,.85);
   backdrop-filter:saturate(150%) blur(8px);
-  border-bottom:1px solid #f1e7db
+  border-bottom:1px solid #f1e7db;
+  animation:glassFade .6s ease-out;
+  transition:background .3s ease, backdrop-filter .3s ease;
 }
 header .wrap.nav{
   display:flex;align-items:center;justify-content:unset;


### PR DESCRIPTION
## Summary
- Introduce `glassFade` keyframes that fade in header background and blur
- Animate sticky header with a short ease-out and add transitions for smoother changes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c060096083328a18ec3b1f862d7c