### PR TITLE
Restrict service worker caching to same-origin GET requests

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -30,14 +30,21 @@ self.addEventListener('activate', (event) => {
 
 // Fetch: network-first with cache fallback
 self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  // Only handle GET requests to our own origin
+  if (request.method !== 'GET') return;
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
   event.respondWith(
-    fetch(event.request)
+    fetch(request)
       .then((networkResp) => {
         // Save a copy in cache
         const copy = networkResp.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
         return networkResp;
       })
-      .catch(() => caches.match(event.request))
+      .catch(() => caches.match(request))
   );
 });


### PR DESCRIPTION
## Summary
- Handle only same-origin GET requests in the service worker
- Skip caching for other requests to avoid storing arbitrary content

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beec2c7e908332905b6b30ec62c09b