### PR TITLE
Add SRI and crossorigin to Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
 
 <!-- Fonts -->
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Playfair+Display:wght@400;600&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Playfair+Display:wght@400;600&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet" integrity="sha384-8hsyITCUg68jU6rixcjlvAl103AMO5e8qhYu/66rabRWhtOjrIWKCSgf1/4khUTM" crossorigin="anonymous">
 
 <style>
 :root{


### PR DESCRIPTION
## Summary
- Add `integrity` and `crossorigin` attributes to Google Fonts stylesheet link
- Preconnect to Google Fonts domain with crossorigin for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -L 'https://fonts.googleapis.com/css2?family=Great+Vibes&family=Playfair+Display:wght@400;600&family=Poppins:wght@300;400;600&display=swap' -o /tmp/font.css`
- `cat /tmp/font.css | openssl dgst -sha384 -binary | openssl base64 -A`
- `curl -L -H 'User-Agent: Mozilla/5.0' -H 'Referer: https://fonts.googleapis.com/' 'https://fonts.gstatic.com/s/greatvibes/v21/RWmMoKWR9v4ksMfaWd_JN-XC.ttf' -o /tmp/font.ttf` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68beecf16e5483329419c6ff8cd11a2f