### PR TITLE
Add dismissible info banner with contact link

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,12 +238,26 @@ input[type="date"]{-webkit-appearance:none;appearance:none;background-clip:paddi
 @media (max-width:820px){ .tier-ff{grid-template-columns:1fr} }
 .tier-ff h4{margin:.2rem 0 .2rem;font:600 1rem "Playfair Display",serif;color:#2b2222}
 .tier-ff .box{border:1px solid #f0e6da;border-radius:12px;padding:12px;background:#fff}
+
+/* Info banner */
+#info-banner{background:var(--accent);color:#fff}
+#info-banner .banner-content{display:flex;align-items:center;justify-content:center;gap:12px;flex-wrap:wrap;position:relative;padding:8px 40px}
+#info-banner .banner-btn{display:inline-block;background:#fff;color:var(--accent);padding:6px 12px;border-radius:999px;font-weight:600}
+#info-banner .banner-close{position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:0;color:#fff;font-size:1.2rem;line-height:1;cursor:pointer}
 </style>
 </head>
 <body>
 
 <!-- Hidden LCP hint for hero background -->
 <img src="IMAGES/IMG_4972.jpg" alt="" width="1200" height="800" decoding="async" fetchpriority="high" aria-hidden="true" inert style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">
+
+<div id="info-banner">
+  <div class="wrap banner-content">
+    <span>Have a question about a custom cake?</span>
+    <a href="#contact" class="banner-btn">Contact us</a>
+    <button id="banner-close" class="banner-close" aria-label="Close banner">&times;</button>
+  </div>
+</div>
 
 <header>
   <div class="wrap nav">
@@ -1111,6 +1125,12 @@ calc();
     a.addEventListener('click', openIG, {passive:false});
   });
 })();
+</script>
+
+<script>
+document.getElementById('banner-close')?.addEventListener('click', function(){
+  document.getElementById('info-banner').style.display='none';
+});
 </script>
 
 <!-- Version: Betti’s Sweets — UB+12 logo-tune DEBUG2 (L+28.2b) — 2025-08-25 -->


### PR DESCRIPTION
## Summary
- Add info banner before the header to highlight contact link
- Style banner with accent color and responsive layout
- Include close button and script to hide banner when dismissed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bef0d4596c83328f982d352bcae8a0