### PR TITLE
Enable glare effect on hero card

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,9 @@ select,input[type="number"],input[type="text"],input[type="date"],input[type="fi
 .iconbtn span + svg{margin-left:8px}
 .iconbtn span{display:inline-block;white-space:nowrap}
 
+.btn, .iconbtn, .fab-ig, nav a, .glass{position:relative;overflow:hidden}
+.btn, .iconbtn, .fab-ig, nav a{transition:transform .2s}
+
 /* Action buttons uniform on mobile */
 @media (max-width:820px){
   .paybuttons .iconbtn{width:100%;justify-content:flex-start}
@@ -273,7 +276,7 @@ input[type="date"]{-webkit-appearance:none;appearance:none;background-clip:paddi
 <!-- Main -->
 <main id="home" class="hero" role="main">
   <div class="wrap">
-    <div class="glass">
+    <div class="glass btn-glare">
       <span class="tag">Salford • Manchester, UK</span>
       <h1 class="big">Custom made artisan cakes</h1>
       <div class="script scriptline">Freshly baked for you.</div>


### PR DESCRIPTION
## Summary
- Enable glare effect on hero's frosted card by adding `btn-glare` class
- Separate button positioning and transition rules and apply them to `.glass`

## Testing
- `npx -y prettier --check index.html` *(fails: Code style issues found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf098bae7883329fdffb736c2b8a01